### PR TITLE
Subtraction

### DIFF
--- a/include/BigInt.h
+++ b/include/BigInt.h
@@ -68,6 +68,9 @@ BigInt* add(BigInt* b1, BigInt* b2);
 // Adds src into destination, growing dest if necessary
 BigInt* add_into(BigInt* src, BigInt* dest);
 
+// Creates a new big int with the sum b1 - b2
+BigInt* subtract(BigInt* b1, BigInt* b2);
+
 void free_BigInt(BigInt* num);
 
 void display(BigInt* num);

--- a/include/BigInt.h
+++ b/include/BigInt.h
@@ -71,6 +71,9 @@ BigInt* add_into(BigInt* src, BigInt* dest);
 // Creates a new big int with the sum b1 - b2
 BigInt* subtract(BigInt* b1, BigInt* b2);
 
+// Subtracts src from dest, growing dest if necessary
+BigInt* subtract_from(BigInt* src, BigInt* dest);
+
 void free_BigInt(BigInt* num);
 
 void display(BigInt* num);

--- a/src/BigInt.c
+++ b/src/BigInt.c
@@ -24,70 +24,6 @@ struct BigInt
 /*******************************************************************************
 * STATIC MEMBER FUNCTIONS
 *******************************************************************************/
-
-#if defined( BIGINT__x64 )
-
-static bucket_t add_with_carry(bucket_t *carry, bucket_t b1, bucket_t b2) 
-{
-    bucket_t sum;
-    bucket_t carry_in = *carry;
-    uint8_t carry_out;
-
-    asm(
-        "xorq	%0, %0\n\t"
-        "cmpq   %4, %0\n\t"
-        "movq	%2, %0\n\t"
-        "adcq	%3, %0\n\t"
-        "setc	%1\n\t"
-        : "=&rm" (sum), "=&rm"(carry_out)
-        : "rm" (b1), "rm" (b2), "r" (carry_in)
-        : "cc"
-    );
-
-    *carry = carry_out;
-    return sum;
-}
-
-#elif defined( BIGINT__x86 )
-
-static bucket_t add_with_carry(bucket_t *carry, bucket_t b1, bucket_t b2) 
-{
-    bucket_t sum;
-    bucket_t carry_in = *carry;
-    uint8_t carry_out;
-
-    asm(
-        "xorl	%0, %0\n\t"
-        "cmpl   %4, %0\n\t"
-        "movl	%2, %0\n\t"
-        "adcl	%3, %0\n\t"
-        "setc	%1\n\t"
-        : "=&rm" (sum), "=&rm"(carry_out)
-        : "rm" (b1), "rm" (b2), "r" (carry_in)
-        : "cc"
-    );
-
-    *carry = carry_out;
-    return sum;
-}
-
-#else
-
-static bucket_t add_with_carry(bucket_t* carry, bucket_t b1, bucket_t b2) 
-{
-    bucket_t sum = b1;
-
-    uint8_t carry_in = (sum += *carry) < b1 ? 1 : 0;
-
-    uint8_t carry_out = (sum += b2) < b2 ? 1 : carry_in;
-
-    *carry = carry_out;
-
-    return sum;
-}
-
-#endif
-
 static int count_hex_digits(bucket_t num)
 {
     if(num == 0)
@@ -216,14 +152,6 @@ static const char* fill_buckets(const char* start, const char* end,
         return start;
 }
 
-static void swap (BigInt** b1, BigInt** b2)
-{
-    BigInt* temp = *b1;
-    *b1 = *b2;
-    *b2 = temp;
-    return;
-}
-
 static size_t leading_bucket(BigInt* num)
 {
     if(num)
@@ -332,6 +260,144 @@ BigInt* str_BigInt(const char* str_num)
 * ARITHMETIC
 *******************************************************************************/
 
+#if defined( BIGINT__x64 )
+
+static bucket_t add_with_carry(bucket_t *carry, bucket_t b1, bucket_t b2) 
+{
+    bucket_t sum;
+    bucket_t carry_in = *carry;
+    uint8_t carry_out;
+
+    asm(
+        "xorq	%0, %0\n\t"
+        "cmpq   %4, %0\n\t"
+        "movq	%2, %0\n\t"
+        "adcq	%3, %0\n\t"
+        "setc	%1\n\t"
+        : "=&rm" (sum), "=&rm"(carry_out)
+        : "rm" (b1), "rm" (b2), "r" (carry_in)
+        : "cc"
+    );
+
+    *carry = carry_out;
+    return sum;
+}
+
+static bucket_t subtract_with_carry(bucket_t* carry, bucket_t b1, bucket_t b2)
+{
+    bucket_t sum;
+    bucket_t carry_in = *carry;
+    uint8_t carry_out;
+
+    asm(
+        "xorq	%0, %0\n\t"
+        "cmpq   %4, %0\n\t"
+        "movq	%2, %0\n\t"
+        "sbbq	%3, %0\n\t"
+        "setc	%1\n\t"
+        : "=&rm" (sum), "=&rm"(carry_out)
+        : "rm" (b1), "rm" (b2), "r" (carry_in)
+        : "cc"
+    );
+
+    *carry = carry_out;
+    return sum;
+}
+
+#elif defined( BIGINT__x86 )
+
+static bucket_t add_with_carry(bucket_t *carry, bucket_t b1, bucket_t b2) 
+{
+    bucket_t sum;
+    bucket_t carry_in = *carry;
+    uint8_t carry_out;
+
+    asm(
+        "xorl	%0, %0\n\t"
+        "cmpl   %4, %0\n\t"
+        "movl	%2, %0\n\t"
+        "adcl	%3, %0\n\t"
+        "setc	%1\n\t"
+        : "=&rm" (sum), "=&rm"(carry_out)
+        : "rm" (b1), "rm" (b2), "r" (carry_in)
+        : "cc"
+    );
+
+    *carry = carry_out;
+    return sum;
+}
+
+static bucket_t subtract_with_carry(bucket_t* carry, bucket_t b1, bucket_t b2)
+{
+    bucket_t sum;
+    bucket_t carry_in = *carry;
+    uint8_t carry_out;
+
+    asm(
+        "xorl	%0, %0\n\t"
+        "cmpl   %4, %0\n\t"
+        "movl	%2, %0\n\t"
+        "sbbl	%3, %0\n\t"
+        "setc	%1\n\t"
+        : "=&rm" (sum), "=&rm"(carry_out)
+        : "rm" (b1), "rm" (b2), "r" (carry_in)
+        : "cc"
+    );
+
+    *carry = carry_out;
+    return sum;}
+
+#else
+
+static bucket_t add_with_carry(bucket_t* carry, bucket_t b1, bucket_t b2) 
+{
+    bucket_t sum = b1;
+
+    uint8_t carry_in = (sum += *carry) < b1 ? 1 : 0;
+
+    uint8_t carry_out = (sum += b2) < b2 ? 1 : carry_in;
+
+    *carry = carry_out;
+
+    return sum;
+}
+
+static bucket_t subtract_with_carry(bucket_t* carry, bucket_t b1, bucket_t b2)
+{
+    bucket_t sum = b1;
+
+    uint8_t carry_in = (sum -= *carry) > b1 ? 1 : 0;
+
+    uint8_t carry_out = (sum -= b2) > b2 ? 1 : carry_in;
+
+    *carry = carry_out;
+
+    return sum;
+}
+
+#endif
+
+
+static BigInt* evaluate(BigInt* b1, BigInt* b2, BigInt* dest, 
+                        size_t b1_buckets, size_t b2_buckets, 
+                        bucket_t (*operation)(bucket_t*, bucket_t, bucket_t))
+{
+    bucket_t carry_out = 0;
+
+    size_t i = 0;
+    for(; i < b2_buckets; ++i)
+    {
+        dest->value[i] = operation(&carry_out, b1->value[i], b2->value[i]);
+    }
+    for(; i < b1_buckets; ++i)
+    {
+        dest->value[i] = operation(&carry_out, b1->value[i], 0);
+    }
+    dest->value[i] = carry_out;
+
+    return dest;
+}
+
 BigInt* add(BigInt* b1, BigInt* b2)
 {
     if(b1 == NULL || b2 == NULL)
@@ -341,29 +407,26 @@ BigInt* add(BigInt* b1, BigInt* b2)
 
     size_t b1_buckets = leading_bucket(b1);
     size_t b2_buckets = leading_bucket(b2);
+    bucket_t (*operation)(bucket_t*, bucket_t, bucket_t) = 
+        (b1->sign < 0 || b2->sign < 0) ? subtract_with_carry : add_with_carry;
+
+    BigInt* result;
+
     if(b1_buckets < b2_buckets)
     {
-        swap(&b1, &b2);
-        size_t temp = b1_buckets;
-        b1_buckets = b2_buckets;
-        b2_buckets = temp;
+        result = reserve_BigInt(b2_buckets + 1);
+        evaluate(b2, b1, result, b2_buckets, b1_buckets, operation);
     }
-
-    bucket_t carry_out = 0;
-
-    BigInt* result = reserve_BigInt(b1_buckets + 1);
-
-    size_t i = 0;
-    for(; i < b2_buckets; ++i)
+    else
     {
-        result->value[i] = add_with_carry(&carry_out, b1->value[i], b2->value[i]);
+        result = reserve_BigInt(b1_buckets + 1);
+        evaluate(b1, b2, result, b1_buckets, b2_buckets, operation);
     }
-    for(; i < b1_buckets; ++i)
-    {
-        result->value[i] = add_with_carry(&carry_out, b1->value[i], 0);
-    }
-    result->value[i] = carry_out;
 
+    if(operation == subtract_with_carry && b2_buckets > b1_buckets)
+    {
+        result->sign = -1;
+    }
     return result;
 }
 
@@ -373,26 +436,32 @@ BigInt* add_into(BigInt* src, BigInt* dest)
     {
         return NULL;
     }
+
     size_t src_buckets = leading_bucket(src);
     if(dest->nbuckets <= src_buckets)
     {
         grow_BigInt(dest, src_buckets - dest->nbuckets + 1);
     }
+    return evaluate(dest, src, dest, dest->nbuckets, src_buckets, add_with_carry);
+}
 
-    bucket_t carry_out = 0;
-
-    size_t i = 0;
-    for(; i < src_buckets; ++i)
+BigInt* subtract(BigInt* b1, BigInt* b2)
+{
+    if(b1 == NULL || b2 == NULL)
     {
-        dest->value[i] = add_with_carry(&carry_out, dest->value[i], src->value[i]);
+        return NULL;
     }
-    for(; i < dest->nbuckets; ++i)
-    {
-        dest->value[i] = add_with_carry(&carry_out, dest->value[i], 0);
-    }
-    dest->value[i] = carry_out;
 
-    return dest;
+    uint8_t sign = b2->sign;
+    if(sign > 0)
+    {
+        b2->sign = -1;
+    }
+
+    BigInt* result = add(b1, b2);
+    b2->sign = sign;
+
+    return result;
 }
 
 /*******************************************************************************

--- a/tests/BigInt_tests.cpp
+++ b/tests/BigInt_tests.cpp
@@ -64,7 +64,7 @@ TEST_CASE("Constructing BigInt's with values <= BUCKET_MAX_SIZE", "[constructors
         REQUIRE(compare_uint(num, test_val) == 0);
         free_BigInt(num);
     }
-    SECTION("Consturction without '0x' prefix on hexadecimal string")
+    SECTION("Construction without '0x' prefix on hexadecimal string")
     {
         int test_val = 1;
         const char* test_str = "1";
@@ -304,6 +304,31 @@ TEST_CASE("Adding BigInts to produce a new BigInt", "[add]")
         free_BigInt(num2);
         free_BigInt(result);
     }
+    SECTION("Adding a negative results in subtraction")
+    {
+        BigInt* num1 = val_BigInt(0xff);
+        BigInt* num2 = str_BigInt("-0x0f");
+
+        BigInt* result = add(num1, num2);
+        REQUIRE(compare_uint(result, 0xf0) == 0);
+
+        free_BigInt(num1);
+        free_BigInt(num2);
+        free_BigInt(result);
+    }
+    SECTION("Adding a larger negative flips the sign")
+    {
+        BigInt* num1 = val_BigInt(0x0f);
+        BigInt* num2 = str_BigInt("-0xff");
+
+        BigInt* result = add(num1, num2);
+        REQUIRE(compare_uint(result, 0) == 0);
+        REQUIRE(sign(result)< 0);
+
+        free_BigInt(num1);
+        free_BigInt(num2);
+        free_BigInt(result);
+    }
     SECTION("BUCKET_MAX + BUCKET_MAX returns 2 BUCKET_MAX")
     {
 #if defined( BIGINT__x64 )
@@ -351,7 +376,7 @@ TEST_CASE("Adding BigInts to produce a new BigInt", "[add]")
         free_BigInt(num2);
         free_BigInt(num3);
     }
-    SECTION("Fib sequence")
+    SECTION("Fib sequence sample")
     {
         bucket_t expected_values[] = { 0x62, 0x2 };
 
@@ -369,7 +394,7 @@ TEST_CASE("Adding BigInts to produce a new BigInt", "[add]")
         free_BigInt(num2);
         free_BigInt(num3);
     }
-    SECTION("Fib sequence 2")
+    SECTION("Fib sequence sample 2")
     {
         bucket_t expected_values[] = { 0x31, 0xda, 0x1 };
 
@@ -457,6 +482,23 @@ TEST_CASE("Adding BigInt into another BigInt", "[add_into]")
         free_BigInt(num2);
     }
 #endif
+}
+
+TEST_CASE("Subtracting BigInts", "[subtract]")
+{
+    SECTION("Trivial Subtraction")
+    {
+        BigInt* num1 = val_BigInt(5);
+        BigInt* num2 = val_BigInt(3);
+
+        BigInt* result = subtract(num1, num2);
+
+        REQUIRE(compare_uint(result, 2) == 0);
+
+        free_BigInt(num1);
+        free_BigInt(num2);
+        free_BigInt(result);
+    }
 }
 
 TEST_CASE("Converting characters to integer values", "[char_to_num]")


### PR DESCRIPTION
Implemented subtract and subtract_from() methods. Both subtract methods act as a wrapper for the add and add_into methods. By adding sign support to the addition functions and implementing a subtract with carry subroutine we can now use the add and add_into function for both addition and subtraction. Unit tests added, all tests pass. 